### PR TITLE
cpufreq: limit max scaling freq

### DIFF
--- a/rootdir/etc/init.qcom.power.rc
+++ b/rootdir/etc/init.qcom.power.rc
@@ -27,6 +27,8 @@ on enable-low-power
     write /sys/module/msm_show_resume_irq/parameters/debug_mask 1
     write /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq 384000
     write /sys/devices/system/cpu/cpu1/cpufreq/scaling_min_freq 384000
+    write /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq 1728000
+    write /sys/devices/system/cpu/cpu1/cpufreq/scaling_max_freq 1728000
     chown root system /sys/devices/system/cpu/cpu1/online
     chmod 664 /sys/devices/system/cpu/cpu1/online
 


### PR DESCRIPTION
guess thats the only way to limit the max freq on early boot when overclocking is enabled
